### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04  # Use Ubuntu 20.04 for glibc 2.31 compatibility
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/SulfurNitride/NaK/security/code-scanning/1](https://github.com/SulfurNitride/NaK/security/code-scanning/1)

The correct way to fix this problem is to add a `permissions:` block to the workflow. In this workflow, the minimal permissions required should be specified based on the operations performed:

- Most of the workflow requires only `contents: read` to read and check out code.
- The release upload (`softprops/action-gh-release@v1`) step must be allowed to create or update releases (needs `contents: write`).
- Uploading artifacts via `actions/upload-artifact@v4` does **not** need write access to repository contents or issues.
- Since the write operations are only necessary for releasing, the recommended approach is:
  1. Add a `permissions:` block at the job (`build:`) level (or at the top-level, if all jobs need the same permissions).
  2. For most jobs, specify `contents: read`.
  3. For the build job, **if the release upload step exists**, use `contents: write` to allow pushing to releases. Otherwise, use the most minimal permissions.

If the release upload step is conditionally invoked, and cannot be separated into another job, then use `contents: write` for job-level permissions. For maximum precision, you can also specify other permissions such as `pull-requests` (not needed here) or restrict to only those necessary.

**Best implementation:**  
- Add the following in the workflow directly under the job (`build:`) level:
  ```yaml
  permissions:
    contents: write
  ```
  Or if you prefer finer restrictions, set only the permissions you need. Since release upload is performed, we need write access to `contents`.

**Change needed:**  
- Insert a `permissions:` block under line 13 (i.e., just before `runs-on:` for the `build` job).
- No additional imports or packages are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
