### PR TITLE
Add proton-cachyos path to _find_custom_proton_versions

### DIFF
--- a/src/utils/proton_finder.py
+++ b/src/utils/proton_finder.py
@@ -208,6 +208,7 @@ class ProtonFinder:
             Path.home() / ".steam" / "steam",
             Path.home() / ".local" / "share" / "Steam",
             Path.home() / ".var" / "app" / "com.valvesoftware.Steam" / "data" / "Steam",  # Flatpak
+            Path("/") / "usr" / "share" / "steam", # proton-cachyos
         ]
 
         for steam_path in steam_paths:


### PR DESCRIPTION
This pull request adds the ability to find proton-cachyos, a custom proton fork made for cachyos.