### PR TITLE
Use ~/.config/NaK in place of ~/NaK when `NAK_XDG_PATH` env var is set

### DIFF
--- a/src/games.rs
+++ b/src/games.rs
@@ -403,8 +403,7 @@ impl GameFixer {
     ) -> Result<(), Box<dyn std::error::Error>> {
         use std::io::Write;
 
-        let home = std::env::var("HOME")?;
-        let tmp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+        let tmp_dir = nak_path!("tmp");
         fs::create_dir_all(&tmp_dir)?;
         let reg_file = tmp_dir.join("game_fix_settings.reg");
 

--- a/src/installers/mo2.rs
+++ b/src/installers/mo2.rs
@@ -19,14 +19,12 @@ pub fn install_mo2(
     proton: &ProtonInfo,
     ctx: TaskContext,
 ) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-
     // Collision Check
     let prefix_mgr = PrefixManager::new();
     let base_name = format!("mo2_{}", install_name.replace(" ", "_").to_lowercase());
     let unique_name = prefix_mgr.get_unique_prefix_name(&base_name);
 
-    let prefix_root = PathBuf::from(format!("{}/NaK/Prefixes/{}/pfx", home, unique_name));
+    let prefix_root = nak_path!("Prefixes", unique_name, "pfx");
     let install_dir = target_install_path;
 
     log_install(&format!(
@@ -68,7 +66,7 @@ pub fn install_mo2(
     ctx.set_status(format!("Downloading {}...", asset.name));
     ctx.set_progress(0.10);
     log_download(&format!("Downloading MO2: {}", asset.name));
-    let archive_path = PathBuf::from(format!("{}/NaK/tmp/{}", home, asset.name));
+    let archive_path = nak_path!("tmp", asset.name);
     download_file(&asset.browser_download_url, &archive_path)?;
     log_download(&format!("MO2 downloaded to: {:?}", archive_path));
 
@@ -211,7 +209,7 @@ pub fn install_mo2(
     log_install("Installing .NET 9 SDK...");
     ctx.set_progress(0.90);
 
-    let tmp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let tmp_dir = nak_path!("tmp");
     fs::create_dir_all(&tmp_dir)?;
     let dotnet_installer = tmp_dir.join("dotnet9_sdk.exe");
 
@@ -343,8 +341,6 @@ pub fn setup_existing_mo2(
     proton: &ProtonInfo,
     ctx: TaskContext,
 ) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-
     // Verify MO2 exists at path
     let mo2_exe = existing_path.join("ModOrganizer.exe");
     if !mo2_exe.exists() {
@@ -363,7 +359,7 @@ pub fn setup_existing_mo2(
     let base_name = format!("mo2_{}", install_name.replace(" ", "_").to_lowercase());
     let unique_name = prefix_mgr.get_unique_prefix_name(&base_name);
 
-    let prefix_root = PathBuf::from(format!("{}/NaK/Prefixes/{}/pfx", home, unique_name));
+    let prefix_root = nak_path!("Prefixes", unique_name, "pfx");
 
     if ctx.is_cancelled() {
         return Err("Cancelled".into());
@@ -480,7 +476,7 @@ pub fn setup_existing_mo2(
     log_install("Installing .NET 9 SDK...");
     ctx.set_progress(0.85);
 
-    let tmp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let tmp_dir = nak_path!("tmp");
     fs::create_dir_all(&tmp_dir)?;
     let dotnet_installer = tmp_dir.join("dotnet9_sdk.exe");
 

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -255,8 +255,7 @@ pub fn apply_wine_registry_settings(
     use std::io::Write;
 
     // Create temp file for registry
-    let home = std::env::var("HOME")?;
-    let tmp_dir = std::path::PathBuf::from(format!("{}/NaK/tmp", home));
+    let tmp_dir = nak_path!("tmp");
     fs::create_dir_all(&tmp_dir)?;
     let reg_file = tmp_dir.join("wine_settings.reg");
 

--- a/src/installers/vortex.rs
+++ b/src/installers/vortex.rs
@@ -21,14 +21,12 @@ pub fn install_vortex(
     proton: &ProtonInfo,
     ctx: TaskContext,
 ) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-
     // Collision Check
     let prefix_mgr = PrefixManager::new();
     let base_name = format!("vortex_{}", install_name.replace(" ", "_").to_lowercase());
     let unique_name = prefix_mgr.get_unique_prefix_name(&base_name);
 
-    let prefix_root = PathBuf::from(format!("{}/NaK/Prefixes/{}/pfx", home, unique_name));
+    let prefix_root = nak_path!("Prefixes", unique_name, "pfx");
     let install_dir = target_install_path;
 
     log_install(&format!(
@@ -77,7 +75,7 @@ pub fn install_vortex(
     ctx.set_status(format!("Downloading {}...", asset.name));
     ctx.set_progress(0.10);
     log_download(&format!("Downloading Vortex: {}", asset.name));
-    let installer_path = PathBuf::from(format!("{}/NaK/tmp/{}", home, asset.name));
+    let installer_path = nak_path!("tmp", asset.name);
     download_file(&asset.browser_download_url, &installer_path)?;
     log_download(&format!("Vortex downloaded to: {:?}", installer_path));
 
@@ -247,7 +245,7 @@ pub fn install_vortex(
     ctx.set_status("Installing .NET 9 SDK...".to_string());
     log_install("Installing .NET 9 SDK...");
     ctx.set_progress(0.90);
-    let tmp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let tmp_dir = nak_path!("tmp");
     fs::create_dir_all(&tmp_dir)?;
     let dotnet_installer = tmp_dir.join("dotnet9_sdk.exe");
     if !dotnet_installer.exists() {
@@ -363,8 +361,6 @@ pub fn setup_existing_vortex(
     proton: &ProtonInfo,
     ctx: TaskContext,
 ) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-
     // Verify Vortex exists at path
     let mut vortex_exe = existing_path.join("Vortex.exe");
     if !vortex_exe.exists() {
@@ -389,7 +385,7 @@ pub fn setup_existing_vortex(
     let base_name = format!("vortex_{}", install_name.replace(" ", "_").to_lowercase());
     let unique_name = prefix_mgr.get_unique_prefix_name(&base_name);
 
-    let prefix_root = PathBuf::from(format!("{}/NaK/Prefixes/{}/pfx", home, unique_name));
+    let prefix_root = nak_path!("Prefixes", unique_name, "pfx");
 
     if ctx.is_cancelled() {
         return Err("Cancelled".into());
@@ -509,7 +505,7 @@ pub fn setup_existing_vortex(
     ctx.set_status("Installing .NET 9 SDK...".to_string());
     log_install("Installing .NET 9 SDK...");
     ctx.set_progress(0.85);
-    let tmp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let tmp_dir = nak_path!("tmp");
     fs::create_dir_all(&tmp_dir)?;
     let dotnet_installer = tmp_dir.join("dotnet9_sdk.exe");
     if !dotnet_installer.exists() {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,9 +5,9 @@
 use chrono::Local;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{Arc, Mutex, OnceLock};
+
 
 static LOGGER: OnceLock<Arc<Mutex<NakLogger>>> = OnceLock::new();
 
@@ -286,8 +286,7 @@ pub struct NakLogger {
 
 impl NakLogger {
     pub fn new() -> Self {
-        let home = std::env::var("HOME").unwrap_or_default();
-        let log_dir = PathBuf::from(format!("{}/NaK/logs", home));
+        let log_dir = nak_path!("logs");
         let _ = fs::create_dir_all(&log_dir);
 
         let timestamp = Local::now().format("%Y%m%d_%H%M%S");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@
 
 use eframe::egui;
 
+#[macro_use]
+mod paths;
+
 mod app;
 mod config;
 mod games;

--- a/src/nxm.rs
+++ b/src/nxm.rs
@@ -9,13 +9,12 @@ pub struct NxmHandler;
 impl NxmHandler {
     pub fn setup() -> Result<(), Box<dyn Error>> {
         let home = std::env::var("HOME")?;
-        let nak_dir = PathBuf::from(format!("{}/NaK", home));
-        let script_path = nak_dir.join("nxm_handler.sh");
+        let script_path = nak_path!("nxm_handler.sh");
         let applications_dir = PathBuf::from(format!("{}/.local/share/applications", home));
         let desktop_path = applications_dir.join("nak-nxm-handler.desktop");
 
         // Ensure directories exist
-        fs::create_dir_all(&nak_dir)?;
+        fs::create_dir_all(nak_path!())?;
         fs::create_dir_all(&applications_dir)?;
 
         // Clean up old NXM handler variations
@@ -40,7 +39,7 @@ impl NxmHandler {
 # NaK Global NXM Handler
 # Forwards nxm:// links to the active mod manager instance (MO2 or Vortex)
 
-ACTIVE_LINK="{}/NaK/active_nxm_game"
+ACTIVE_LINK="{}/active_nxm_game"
 
 if [ ! -L "$ACTIVE_LINK" ]; then
     zenity --error --text="No active mod manager instance selected in NaK!" --title="NaK Error"
@@ -81,7 +80,7 @@ fi
 # Run the mod manager with the NXM link
 "$LAUNCHER" "$1"
 "#,
-            home
+            nak_path!().display()
         );
 
         let mut file = fs::File::create(&script_path)?;
@@ -120,8 +119,7 @@ MimeType=x-scheme-handler/nxm;
     }
 
     pub fn set_active_instance(install_dir: &Path) -> Result<(), Box<dyn Error>> {
-        let home = std::env::var("HOME")?;
-        let link_path = PathBuf::from(format!("{}/NaK/active_nxm_game", home));
+        let link_path = nak_path!("active_nxm_game");
 
         if link_path.exists() || fs::symlink_metadata(&link_path).is_ok() {
             let _ = fs::remove_file(&link_path);

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,39 @@
+use std::{path::PathBuf, sync::LazyLock};
+
+pub static DEFAULT_NAK_PATH: LazyLock<PathBuf> = LazyLock::new(|| {
+    let mut path = std::env::home_dir().unwrap_or_default();
+    
+    if std::env::var("NAK_XDG_PATH").is_ok() {
+        path.push(".config")
+    }
+    
+    path.push("NaK");
+    path
+});
+
+/// Computes the path from the NaK config directory based on the arguments.
+///
+/// Returns a `&Path` referencing the config directory itself if no arguments are passed in, or a
+/// `PathBuf` created by joining all of the arguments to the base config directory if at least
+/// one argument is passed in.
+///
+/// # Examples
+///
+/// ```
+/// // Assuming `NAK_XDG_PATH` is not set specified, the default config path is ~/NaK
+/// assert_eq!(Some(nak_path!()), std::env::home_dir().join("Nak"));
+/// assert_eq!(Some(nak_path!("foo", "bar")), std::env::home_dir().join("Nak").join("foo").join("bar"));
+/// ```
+#[macro_export]
+macro_rules! nak_path {
+    () => {
+        $crate::paths::DEFAULT_NAK_PATH.as_path()
+    };
+
+    ( $( $path:expr ),+ $(,)? ) => {
+        [
+            $crate::paths::DEFAULT_NAK_PATH.as_path(),
+            $( std::path::Path::new(&$path) ),+
+        ].into_iter().collect::<std::path::PathBuf>()
+    };
+}

--- a/src/ui/mod_managers.rs
+++ b/src/ui/mod_managers.rs
@@ -343,7 +343,7 @@ fn render_install_wizard(
                     ui.label(format!("Error: {}", error_msg));
                     ui.add_space(10.0);
                     ui.label(egui::RichText::new("Please check the logs for more details:").strong());
-                    ui.label("~/NaK/logs");
+                    ui.label(nak_path!("logs").to_string_lossy());
                 } else {
                     ui.heading("Installation Successful!");
                     ui.add_space(10.0);

--- a/src/ui/pages.rs
+++ b/src/ui/pages.rs
@@ -207,7 +207,7 @@ pub fn render_settings(app: &mut MyApp, ui: &mut egui::Ui) {
                             ui.horizontal(|ui| {
                                 ui.label("• Other:");
                                 ui.strong(format!("{:.2} GB", storage_info.other_size_gb))
-                                  .on_hover_text("Includes logs, config files, and binaries in ~/NaK");
+                                  .on_hover_text(format!("Includes logs, config files, and binaries in {}", nak_path!().display()));
                             });
                         }
                     });
@@ -323,15 +323,11 @@ pub fn render_settings(app: &mut MyApp, ui: &mut egui::Ui) {
                 ui.add_space(5.0);
 
                 if ui.button("📂 Open NaK Folder").clicked() {
-                    let home = std::env::var("HOME").unwrap_or_default();
-                    let nak_path = format!("{}/NaK", home);
-                    let _ = std::process::Command::new("xdg-open").arg(&nak_path).spawn();
+                    let _ = std::process::Command::new("xdg-open").arg(nak_path!()).spawn();
                 }
 
                 if ui.button("📂 Open Logs Folder").clicked() {
-                    let home = std::env::var("HOME").unwrap_or_default();
-                    let logs_path = format!("{}/NaK/logs", home);
-                    let _ = std::process::Command::new("xdg-open").arg(&logs_path).spawn();
+                    let _ = std::process::Command::new("xdg-open").arg(nak_path!("logs")).spawn();
                 }
             });
     });

--- a/src/wine/prefixes.rs
+++ b/src/wine/prefixes.rs
@@ -19,9 +19,8 @@ pub struct PrefixManager {
 #[allow(dead_code)]
 impl PrefixManager {
     pub fn new() -> Self {
-        let home = std::env::var("HOME").expect("Failed to get HOME");
         Self {
-            prefixes_root: PathBuf::from(format!("{}/NaK/Prefixes", home)),
+            prefixes_root: nak_path!("Prefixes")
         }
     }
 

--- a/src/wine/proton.rs
+++ b/src/wine/proton.rs
@@ -31,8 +31,8 @@ impl ProtonFinder {
         let home = std::env::var("HOME").expect("Failed to get HOME directory");
         Self {
             steam_root: PathBuf::from(format!("{}/.steam/steam", home)),
-            nak_proton_ge_root: PathBuf::from(format!("{}/NaK/ProtonGE", home)),
-            nak_proton_cachyos_root: PathBuf::from(format!("{}/NaK/ProtonCachyOS", home)),
+            nak_proton_ge_root: nak_path!("ProtonGE"),
+            nak_proton_cachyos_root: nak_path!("ProtonCachyOS"),
         }
     }
 
@@ -162,8 +162,7 @@ impl ProtonFinder {
 
 /// Sets the 'active' symlink for the selected proton (at ~/NaK/ProtonGE/active)
 pub fn set_active_proton(proton: &ProtonInfo) -> Result<(), Box<dyn std::error::Error>> {
-    let home = std::env::var("HOME")?;
-    let active_link = PathBuf::from(format!("{}/NaK/ProtonGE/active", home));
+    let active_link = nak_path!("ProtonGE", "active");
 
     // Remove existing symlink if present
     if active_link.exists() || fs::symlink_metadata(&active_link).is_ok() {
@@ -274,9 +273,8 @@ where
     F: Fn(u64, u64) + Send + 'static,
     S: Fn(&str) + Send + 'static,
 {
-    let home = std::env::var("HOME")?;
-    let install_root = PathBuf::from(format!("{}/NaK/ProtonGE", home));
-    let temp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let install_root = nak_path!("ProtonGE");
+    let temp_dir = nak_path!("tmp");
 
     fs::create_dir_all(&install_root)?;
     fs::create_dir_all(&temp_dir)?;
@@ -329,8 +327,7 @@ where
 
 /// Deletes a GE-Proton version
 pub fn delete_ge_proton(version_name: &str) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-    let install_path = PathBuf::from(format!("{}/NaK/ProtonGE/{}", home, version_name));
+    let install_path = nak_path!("ProtonGE", version_name);
 
     if install_path.exists() {
         fs::remove_dir_all(install_path)?;
@@ -366,9 +363,8 @@ where
 {
     use xz2::read::XzDecoder;
 
-    let home = std::env::var("HOME")?;
-    let install_root = PathBuf::from(format!("{}/NaK/ProtonCachyOS", home));
-    let temp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let install_root = nak_path!("ProtonCachyOS");
+    let temp_dir = nak_path!("tmp");
 
     fs::create_dir_all(&install_root)?;
     fs::create_dir_all(&temp_dir)?;
@@ -421,8 +417,7 @@ where
 
 /// Deletes a CachyOS Proton version
 pub fn delete_cachyos_proton(version_name: &str) -> Result<(), Box<dyn Error>> {
-    let home = std::env::var("HOME")?;
-    let install_path = PathBuf::from(format!("{}/NaK/ProtonCachyOS/{}", home, version_name));
+    let install_path = nak_path!("ProtonCachyOS", version_name);
 
     if install_path.exists() {
         fs::remove_dir_all(install_path)?;

--- a/src/wine/runtime.rs
+++ b/src/wine/runtime.rs
@@ -10,8 +10,7 @@ use tar::Archive;
 
 pub fn find_steam_runtime_sniper() -> Option<PathBuf> {
     // Check NaK standalone installation ONLY
-    let home = std::env::var("HOME").expect("Failed to get HOME");
-    let nak_runtime = PathBuf::from(format!("{}/NaK/Runtime/SteamLinuxRuntime_sniper", home));
+    let nak_runtime = nak_path!("Runtime", "SteamLinuxRuntime_sniper");
 
     if nak_runtime.join("_v2-entry-point").exists() {
         return Some(nak_runtime);
@@ -32,9 +31,8 @@ pub fn download_runtime<F>(progress_callback: F) -> Result<PathBuf, Box<dyn Erro
 where
     F: Fn(u64, u64) + Send + 'static,
 {
-    let home = std::env::var("HOME")?;
-    let install_root = PathBuf::from(format!("{}/NaK/Runtime", home));
-    let temp_dir = PathBuf::from(format!("{}/NaK/tmp", home));
+    let install_root = nak_path!("Runtime");
+    let temp_dir = nak_path!("tmp");
 
     fs::create_dir_all(&install_root)?;
     fs::create_dir_all(&temp_dir)?;


### PR DESCRIPTION
Hello! This is a really awesome project that I somehow hadn't realized existed until last night. I tend to be a bit pedantic about trying to keep my home directory relatively empty, so I wanted to be able to put the configs for this somewhere else besides `~/NaK`. (I noticed the option to migrate it elsewhere, but I'd also prefer not to have to leave a symlink pointing to the new directory).

Since there's not an easy way to specify an alternate location via config files themselves (or else there isn't any way to know where to find the config in the first place), the only obvious ways would be via a CLI arg or environmental variable. Most of the ways for dealing with CLI args in Rust end up using dependencies, and rather than try to guess which of the various libraries you might want to use, going with an environmental variable seemed simpler. I considered whether it would make sense to allow specifying an arbitrary path rather than hardcoding one, but I realized that any path someone wants to supply would probably utilize the `~` shorthand, and since from what I can tell there currently isn't any handling for expansions like that in NaK currently, I didn't think it made sense for me to try to propose a much larger change like that (at least in this context; if it's something you'd be interested in having a PR for I might be interested!).

With all of that background in mind, this PR changes NaK to store everything under `~/.config/NaK` rather than `~/Nak` when the env var `NAK_XDG_PATH` is set. I tried to minimize the number of changes in existing code when implementing this. Right now there's quite a bit of complexity around various things like symlinking, and although I could imagine that this might be possible to handle in a more uniform way with allowing an arbitrary location for the configuration, I didn't want to risk subtly breaking something when I could provide the functionality I wanted without having to change much of the overall logic.

Since the various path-related types in Rust can sometimes be a bit cumbersome to work with idiomatically (especially if you want to avoid accidentally doing a bunch of extra copies and allocations, which probably wouldn't end up being noticeable in this case but still doesn't hurt to try to minimize if it's not too difficult), I took a stab at writing a macro to provide an easy way to get arbitrarily nested paths under the config directory regardless of whether the alternative is specified via the env var. Although it's not particularly easy to write a regular function that allows combining arbitrary instances of `String`/`&str`/`PathBuf`/`&Path` to join into a single path without some annoying boilerplate when passing them in, a macro can handle this fairly easily (at the cost of the macro implementation potentially looking a bit messy). Overall, this ends up making the places where the paths are needed a bit cleaner, so personally I find it worthwhile, but I figured it was worth calling out still since the macro implementation will probably be a bit intimidating if it's not the type of thing you happen to have experience with in Rust already.

If this isn't something you happen to want to support, I totally understand, and no worries if you decide to close the PR for whatever reason without merging! I also don't mind if you want to manually push to this branch to make changes, copy some or all of the code into your own branch to make the changes directly, or whatever else you might want to do rather than ask me to make changes or merge it as-is. I'm mostly just interested in being able to use NaK with this feature in some fashion, and if that happens, I'm not picky about how exactly it happened. Feel free to consider this code to be licensed as MIT (or whatever else you might want if you ever end up wanting to relicense NaK for some reason).