### PR TITLE
fix: Use config prefix path when setting dpi during new prefix setup

### DIFF
--- a/src/ui/mod_managers.rs
+++ b/src/ui/mod_managers.rs
@@ -897,7 +897,6 @@ fn start_installation(app: &mut MyApp) {
 
 /// Get the prefix path for the current wizard installation
 fn get_wizard_prefix_path(app: &MyApp) -> Option<std::path::PathBuf> {
-    let home = std::env::var("HOME").ok()?;
     let instance_name = &app.install_wizard.name;
     let manager_type = &app.install_wizard.manager_type;
     if instance_name.is_empty() {
@@ -910,11 +909,7 @@ fn get_wizard_prefix_path(app: &MyApp) -> Option<std::path::PathBuf> {
         manager_type.to_lowercase(),
         instance_name.to_lowercase().replace(' ', "_")
     );
-
-    Some(std::path::PathBuf::from(format!(
-        "{}/NaK/Prefixes/{}/pfx",
-        home, prefix_name
-    )))
+    Some(app.config.get_prefixes_path().join(&prefix_name))
 }
 
 /// Handle applying a new DPI value


### PR DESCRIPTION
After creating a new prefix, I noticed that trying to set the DPI would fail until I restarted NaK. From checking the log output, I traced this to the `get_wizard_prefix_path` function assuming the default config location. From testing locally, swapping this to use the `config_path` from `AppConfig` seemed to fix it.

It's a pretty minor bug all things considered, given that it's easily possible to workaround by restarting, but since the fix is small I figured it couldn't hurt to share it back in case it might be worth including.